### PR TITLE
lsInfo patch to support playlists as well

### DIFF
--- a/Network/MPD/Commands.hs
+++ b/Network/MPD/Commands.hs
@@ -374,17 +374,17 @@ listAll path = liftM (map snd . filter ((== "file") . fst) . toAssocList)
                      (getResponse $ "listall" <$> path)
 
 -- Helper for lsInfo and listAllInfo.
-lsInfo' :: MonadMPD m => String -> Path -> m [Either Path Song]
+lsInfo' :: MonadMPD m => String -> Path -> m [Result]
 lsInfo' cmd path =
-    liftM (extractEntries (Just . Right, const Nothing, Just . Left)) $
+    liftM (extractEntries (Just . File, Just . Playlist, Just . Directory)) $
          takeEntries =<< getResponse (cmd <$> path)
 
 -- | Recursive 'lsInfo'.
-listAllInfo :: MonadMPD m => Path -> m [Either Path Song]
+listAllInfo :: MonadMPD m => Path -> m [Result]
 listAllInfo = lsInfo' "listallinfo"
 
 -- | Non-recursively list the contents of a database directory.
-lsInfo :: MonadMPD m => Path -> m [Either Path Song]
+lsInfo :: MonadMPD m => Path -> m [Result]
 lsInfo = lsInfo' "lsinfo"
 
 -- | Search the database using case insensitive matching.

--- a/Network/MPD/Commands/Types.hs
+++ b/Network/MPD/Commands/Types.hs
@@ -109,6 +109,12 @@ data Count =
 defaultCount :: Count
 defaultCount = Count { cSongs = 0, cPlaytime = 0 }
 
+-- | Result of the lsInfo operation
+data Result
+    = Directory Path        -- ^ Directory
+    | File Song             -- ^ Song
+    | Playlist PlaylistName -- ^ Playlist
+
 -- | Represents an output device.
 data Device =
     Device { dOutputID      :: Int    -- ^ Output's ID number


### PR DESCRIPTION
When writing an MPD Browser to replace ncmpcpp, I was surprised by the lack of Playlist information in the result of lsInfo, since this is the only way to get *.cue files within directories.

As such, I have modified my copy of libmpd to support these in the output. As it severely breaks the API, you may do with it as you wish, perhaps introducing them as separate functions for backwards compatibility.
