### PR TITLE
Add a link to my own copy of MPD's protocol documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See our [bug tracker]. Test cases are highly appreciated.
 [GitHub]: http://www.github.com
 [repository]: http://www.github.com/joachifm/libmpd-haskell
 [API documentation]: http://hackage.haskell.org/packages/archive/libmpd/latest/doc/html/Network-MPD.html
-[Protocol reference]: http://www.musicpd.org/doc/protocol/
+[Protocol reference]: http://sol.github.com/libmpd-haskell/protocol/
 [Using GitHub]: http://help.github.com
 
 ## License


### PR DESCRIPTION
Sadly, upstream does not provide this anymore.
