### PR TITLE
GHC 7.6.1 compatibility

### DIFF
--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -46,8 +46,8 @@ Library
       , utf8-string >= 0.3.1 && < 0.4
       , old-locale >= 1.0 && < 2.0
       , time >= 1.1 && < 2.0
-      , containers >= 0.3 && < 0.5
-      , data-default >= 0.4.0 && < 0.5
+      , containers >= 0.3 && <= 0.5.0.0
+      , data-default >= 0.4.0 && <= 0.5.0
       , bytestring >= 0.9 && < 1
       , text >= 0.11 && < 0.12
       , attoparsec >= 0.10.1 && < 0.11


### PR DESCRIPTION
Builds with `containers 0.5.0.0` and `data-default 0.5.0`, the .cabal file just needs the versions bumped.
