### PR TITLE
Bump attoparsec dependency to <0.12

### DIFF
--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -52,7 +52,7 @@ Library
       , data-default >= 0.4.0 && < 0.6
       , bytestring >= 0.9 && < 1
       , text >= 0.11 && < 0.12
-      , attoparsec >= 0.10.1 && < 0.11
+      , attoparsec >= 0.10.1 && < 0.12
 
     Exposed-Modules:
         Network.MPD


### PR DESCRIPTION
Builds fine here, and I need attoparsec 0.11 for lens
