### PR TITLE
Escape special characters when preparing arguments

### DIFF
--- a/src/Network/MPD/Commands/Arg.hs
+++ b/src/Network/MPD/Commands/Arg.hs
@@ -60,7 +60,7 @@ instance MPDArg Args where prep = id
 instance MPDArg String where
     -- We do this to avoid mangling
     -- non-ascii characters with 'show'
-    prep x = Args ['"' : x ++ "\""]
+    prep x = Args ['"' : addSlashes x ++ "\""]
 
 instance MPDArg ByteString where
     prep = prep . UTF8.toString
@@ -76,3 +76,10 @@ instance MPDArg Int
 instance MPDArg Integer
 instance MPDArg Bool where prep = Args . return . showBool
 instance MPDArg Double
+
+addSlashes :: String -> String
+addSlashes = concatMap escapeSpecial
+    where specials = "\\\""
+          escapeSpecial x
+              | x `elem` specials = ['\\', x]
+              | otherwise = [x]


### PR DESCRIPTION
Double quotes `"` and backslashes `\` need to be escaped when sending string arguments.

I am not familiar enough with the testing libraries you have used to write tests for this, unfortunately. I am still fairly new to Haskell. If you could point me at some useful documentation and how you would like it done I'll have a go at writing tests.

Fixes #83
