### PR TITLE
handle status key 'duration' introduced in 0.20

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@ Dmitry Malikov <malikov.d.y@gmail.com>
 Sergei Trofimovich <slyfox@gentoo.org>
 Simon Gomizelj <simongmzlj@gmail.com>
 Matvey Aksenov <matvey.aksenov@gmail.com>
+Tobias Brandt <tob.brandt@gmail.com>

--- a/src/Network/MPD/Applicative/Status.hs
+++ b/src/Network/MPD/Applicative/Status.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, TupleSections #-}
 
 {- |
 Module      : Network.MPD.Applicative.Status
@@ -95,7 +95,8 @@ status = Command (liftParser parseStatus) ["status"]
                 "nextsong"       -> int   $ \x -> a { stNextSongPos     = Just x }
                 "nextsongid"     -> int   $ \x -> a { stNextSongID      = Just $ Id x }
                 "time"           -> time  $ \x -> a { stTime            = Just x }
-                "elapsed"        -> frac  $ \x -> a { stTime            = fmap ((,) x . snd) (stTime a) }
+                "elapsed"        -> frac  $ \x -> a { stTime            = fmap ((x,) . snd) (stTime a) }
+                "duration"       -> frac  $ \x -> a { stTime            = fmap ((,x) . fst) (stTime a) }
                 "bitrate"        -> int   $ \x -> a { stBitrate         = Just x }
                 "xfade"          -> num   $ \x -> a { stXFadeWidth      = x }
                 "mixrampdb"      -> frac  $ \x -> a { stMixRampdB       = x }
@@ -115,7 +116,7 @@ status = Command (liftParser parseStatus) ["status"]
                     -- errors.
                     audio f = Right $ maybe a f (parseTriple ':' parseNum v)
 
-                    time f = case parseFrac *** parseNum $ breakChar ':' v of
+                    time f = case parseFrac *** parseFrac $ breakChar ':' v of
                                  (Just a_, Just b) -> (Right . f) (a_, b)
                                  _                 -> unexpectedPair
 

--- a/src/Network/MPD/Commands/Types.hs
+++ b/src/Network/MPD/Commands/Types.hs
@@ -357,7 +357,7 @@ data Status =
              -- | Next song's playlist ID.
            , stNextSongID      :: Maybe Id
              -- | Time elapsed\/total time of playing song (if any).
-           , stTime            :: Maybe (Double, Seconds)
+           , stTime            :: Maybe (FractionalSeconds, FractionalSeconds)
              -- | Bitrate (in kilobytes per second) of playing song (if any).
            , stBitrate         :: Maybe Int
              -- | Crossfade time.


### PR DESCRIPTION
This commit handles the key *duration* in the response to the *status* command which was introduced in [MPD 0.20](http://www.musicpd.org/doc/protocol/command_reference.html#status_commands). It also changes the type of `stTime` to `Maybe (FractionalSeconds, FractionalSeconds)`.