### PR TITLE
Add support for GHC 7.10

### DIFF
--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -42,12 +42,18 @@ Library
       , mtl >= 2.0 && < 3
       , old-locale >= 1 && < 2
       , text >= 0.11 && < 2
-      , time >= 1.5 && <1.6
 
         -- Additional dependencies
       , data-default-class >= 0.0.1 && < 1
       , network >= 2.1 && < 3
       , utf8-string >= 0.3.1 && < 1
+
+    if impl(ghc >= 7.10.0)
+        Build-Depends:
+            time >= 1.5 && <1.6
+    else
+        Build-Depends:
+            time >= 1.1 && <1.5
 
     Exposed-Modules:
         Network.MPD

--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -42,7 +42,7 @@ Library
       , mtl >= 2.0 && < 3
       , old-locale >= 1 && < 2
       , text >= 0.11 && < 2
-      , time >= 1.1 && < 2
+      , time >= 1.5 && <1.6
 
         -- Additional dependencies
       , data-default-class >= 0.0.1 && < 1

--- a/src/Network/MPD/Commands/CurrentPlaylist.hs
+++ b/src/Network/MPD/Commands/CurrentPlaylist.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
 
 {- |
 Module      : Network.MPD.Commands.CurrentPlaylist

--- a/src/Network/MPD/Util.hs
+++ b/src/Network/MPD/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, CPP #-}
 -- | Module    : Network.MPD.Util
 -- Copyright   : (c) Ben Sinclair 2005-2009, Joachim Fasting 2010
 -- License     : MIT (see LICENSE)
@@ -15,7 +15,13 @@ module Network.MPD.Util (
 
 import           Control.Arrow
 
-import           Data.Time.Format (ParseTime, parseTime, FormatTime, formatTime, defaultTimeLocale)
+import           Data.Time.Format (ParseTime, parseTime, FormatTime, formatTime)
+
+#if MIN_VERSION_time(1,5,0)
+import           Data.Time.Format (defaultTimeLocale)
+#else
+import           System.Locale (defaultTimeLocale)
+#endif
 
 import qualified Prelude
 import           Prelude hiding        (break, take, drop, dropWhile, read)

--- a/src/Network/MPD/Util.hs
+++ b/src/Network/MPD/Util.hs
@@ -15,8 +15,7 @@ module Network.MPD.Util (
 
 import           Control.Arrow
 
-import           Data.Time.Format (ParseTime, parseTime, FormatTime, formatTime)
-import           System.Locale (defaultTimeLocale)
+import           Data.Time.Format (ParseTime, parseTime, FormatTime, formatTime, defaultTimeLocale)
 
 import qualified Prelude
 import           Prelude hiding        (break, take, drop, dropWhile, read)


### PR DESCRIPTION
There have been two changes from GHC 7.8 to 7.10 that require modifications:

1. The `FlexibleContexts` extension is now also required for inferred types. The type of `f` in `Network.MPD.Commands.CurrentPlaylist.playlist` has a flexible context, so we need the pragma. This doesn't do anything for older versions of GHC.

2. GHC now comes with `time` 1.5. The function `defaultTimeLocale` was moved from the `old-locale` package to `time` in this version. We cannot require `time` 1.5 because that's one of those packages that is distributed with the compiler and GHC <7.10 uses `time` 1.4. Therefore, conditional compilation is needed.