### PR TITLE
libmpd.cabal: allow utf8-string-1

### DIFF
--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -46,7 +46,7 @@ Library
         -- Additional dependencies
       , data-default-class >= 0.0.1 && < 1
       , network >= 2.1 && < 3
-      , utf8-string >= 0.3.1 && < 1
+      , utf8-string >= 0.3.1 && < 1.1
 
     if impl(ghc >= 7.10.0)
         Build-Depends:

--- a/src/Network/MPD/Core.hs
+++ b/src/Network/MPD/Core.hs
@@ -36,7 +36,6 @@ import qualified Data.Foldable as F
 import           Network (PortID(..), withSocketsDo, connectTo)
 import           System.IO (Handle, hPutStrLn, hReady, hClose, hFlush)
 import           System.IO.Error (isEOFError, tryIOError, ioeGetErrorType)
-import qualified System.IO.UTF8 as U
 import           Text.Printf (printf)
 import qualified GHC.IO.Exception as GE
 
@@ -45,7 +44,6 @@ import           Prelude hiding (break, drop, dropWhile, read)
 import           Data.ByteString.Char8 (ByteString, isPrefixOf, break, drop, dropWhile)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.UTF8 as UTF8
-
 --
 -- Data types.
 --
@@ -169,7 +167,7 @@ mpdSend str = send' `catchError` handler
         send' = MPD $ gets stHandle >>= maybe (throwError NoMPD) go
 
         go handle = (liftIO . tryIOError $ do
-            unless (null str) $ U.hPutStrLn handle str >> hFlush handle
+            unless (null str) $ B.hPutStrLn handle (UTF8.fromString str) >> hFlush handle
             getLines handle [])
                 >>= either (\err -> modify (\st -> st { stHandle = Nothing })
                                  >> throwError (ConnectionError err)) return


### PR DESCRIPTION
utf8-string-1 got rit od IO functions
and became a pure codec library, thus the tweak:

Instead of using hPutStrLn from 'utf8-string'
use properly encoded one from 'bytestring'.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>