### PR TITLE
Support latest GHC (and latest stackage nightly)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,6 @@ matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.6.3"
-    addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -71,8 +59,6 @@ matrix:
     addons: {apt: {packages: [libgmp10,libgmp-dev]}}
 
   allow_failures:
-  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
   - env: BUILD=stack ARGS="--resolver nightly"
 

--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -19,7 +19,7 @@ Stability:          beta
 Homepage:           http://github.com/vimus/libmpd-haskell#readme
 Bug-reports:        http://github.com/vimus/libmpd-haskell/issues
 
-Tested-With:        GHC ==7.6.3, GHC ==7.8.4, GHC ==7.10.1, GHC ==8.0.1
+Tested-With:        GHC ==8.0.1, GHC==8.2.2, GHC==8.4.3, GHC==8.6.1
 Build-Type:         Simple
 Cabal-Version:      >= 1.10
 
@@ -39,7 +39,7 @@ Library
 
     Build-Depends:
         -- Platform dependencies
-        base >= 4 && < 5
+        base >= 4.9 && < 5
       , attoparsec >= 0.10.1 && < 1
       , bytestring >= 0.9 && < 1
       , containers >= 0.3 && < 1
@@ -50,13 +50,13 @@ Library
 
         -- Additional dependencies
       , data-default-class >= 0.0.1 && < 1
-      , network >= 2.1 && < 3
+      , network >= 2.6.3.5
       , safe-exceptions >= 0.1 && < 0.2
       , utf8-string >= 0.3.1 && < 1.1
 
     if impl(ghc >= 7.10.0)
         Build-Depends:
-            time >= 1.5 && <1.9
+            time >= 1.5
     else
         Build-Depends:
             time >= 1.1 && <1.5

--- a/src/Network/MPD/Applicative/Internal.hs
+++ b/src/Network/MPD/Applicative/Internal.hs
@@ -39,9 +39,7 @@ import           Data.ByteString.Char8 (ByteString)
 import           Network.MPD.Core hiding (getResponse)
 import qualified Network.MPD.Core as Core
 import           Control.Monad.Error
-#if MIN_VERSION_base(4,9,0)
 import qualified Control.Monad.Fail as Fail
-#endif
 
 -- | A line-oriented parser that returns a value along with any remaining input.
 newtype Parser a
@@ -49,14 +47,11 @@ newtype Parser a
       deriving Functor
 
 instance Monad Parser where
-    fail      = Parser . const . Left
     return a  = Parser $ \input -> Right (a, input)
     p1 >>= p2 = Parser $ \input -> runParser p1 input >>= uncurry (runParser . p2)
 
-#if MIN_VERSION_base(4,9,0)
 instance Fail.MonadFail Parser where
     fail = Prelude.fail
-#endif
 
 instance Applicative Parser where
     pure  = return


### PR DESCRIPTION
This PR should be properly reviewed as I have only made sure that it
compiles fine and the test suites are passed.

Summary of the changes:
* Only support latest 4 major GHC's. With xmonad also doing the same,
I made the same decision here.
* In recent version of network (>= 3.0), the connectTo function isn't
present. So, safeConnect function has been changed accordingly. (This
is the part that need review from the person actually using the library).

Related to: https://github.com/xmonad/xmonad-extras/issues/24