### PR TITLE
Omit Volume constructor from Show instance

### DIFF
--- a/src/Network/MPD/Commands/Types.hs
+++ b/src/Network/MPD/Commands/Types.hs
@@ -303,7 +303,10 @@ instance Default Stats where
 -- @current - new = 0   if current - new < 0@
 --
 -- but @current / 0@ still yields a division by zero exception.
-newtype Volume = Volume Int deriving (Eq, Ord, Show)
+newtype Volume = Volume Int deriving (Eq, Ord)
+
+instance Show Volume where
+    showsPrec p (Volume v) = showsPrec p v
 
 instance Enum Volume where
     toEnum = Volume . min 100 . max 0


### PR DESCRIPTION
The derived show instance shows a Volume 50 as "Volume 50", but I think
showing it as "50" makes more sense and is slightly more convenient for
users of the library.

YMMV