### PR TITLE
Fix divMod on Volume

### DIFF
--- a/src/Network/MPD/Commands/Types.hs
+++ b/src/Network/MPD/Commands/Types.hs
@@ -330,6 +330,7 @@ instance Num Volume where
 instance Integral Volume where
     quotRem (Volume x) (Volume y) =
         let (x', y') = x `quotRem` y in (Volume x', Volume y')
+    divMod = quotRem
     toInteger (Volume x) = fromIntegral x
 
 instance Real Volume where


### PR DESCRIPTION
The [default implementation](http://hackage.haskell.org/package/base-4.12.0.0/docs/src/GHC.Real.html#divMod) for divMod decides whether to adjust the result of quotRem based on the results of negate and signum. Since Volume can't be negative this test doesn't work and you end up with incorrect results like 60 `divMod` 5 == (11, 5). The correct behavior is for divMod to behave the same as quotRem.