### PR TITLE
add seekCur command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+* v0.9.2.0
+    - New command: `seekCur`
+    - Add `newtype Sign` to pass positive numbers to `MPDArg` with leading `+/-`.
+
 * v0.9.1.0
     - Support partition in Network.MPD.Status
     - Ignore unknown key-value pairs in Network.MPD.status so that it breaks much less often.

--- a/src/Network/MPD/Applicative/PlaybackControl.hs
+++ b/src/Network/MPD/Applicative/PlaybackControl.hs
@@ -20,6 +20,7 @@ module Network.MPD.Applicative.PlaybackControl
     , previous
     , seek
     , seekId
+    , seekCur
     , stop
     ) where
 
@@ -56,6 +57,13 @@ seek pos time = Command emptyResponse ["seek" <@> pos <++> time]
 -- | Seek to time in the song with the given id.
 seekId :: Id -> FractionalSeconds -> Command ()
 seekId id' time = Command emptyResponse ["seekid" <@> id' <++> time]
+
+-- | Seek to time in the current song. Absolute time for True in
+-- the frist argument, relative time for False.
+seekCur :: Bool -> FractionalSeconds -> Command ()
+seekCur bool time
+  | bool      = Command emptyResponse ["seekcur" <@> time]
+  | otherwise = Command emptyResponse ["seekcur" <@> (Sign time)]
 
 -- | Stop playback.
 stop :: Command ()

--- a/src/Network/MPD/Applicative/PlaybackControl.hs
+++ b/src/Network/MPD/Applicative/PlaybackControl.hs
@@ -60,6 +60,8 @@ seekId id' time = Command emptyResponse ["seekid" <@> id' <++> time]
 
 -- | Seek to time in the current song. Absolute time for True in
 -- the frist argument, relative time for False.
+--
+-- @since 0.9.2.0
 seekCur :: Bool -> FractionalSeconds -> Command ()
 seekCur bool time
   | bool      = Command emptyResponse ["seekcur" <@> time]

--- a/src/Network/MPD/Commands/Arg.hs
+++ b/src/Network/MPD/Commands/Arg.hs
@@ -12,7 +12,7 @@ Portability : unportable
 Prepare command arguments.
 -}
 
-module Network.MPD.Commands.Arg (Command, Args(..), MPDArg(..), (<++>), (<@>)) where
+module Network.MPD.Commands.Arg (Command, Args(..), MPDArg(..), (<++>), (<@>),Sign(..)) where
 
 import           Network.MPD.Util (showBool)
 
@@ -76,6 +76,15 @@ instance MPDArg Int
 instance MPDArg Integer
 instance MPDArg Bool where prep = Args . return . showBool
 instance MPDArg Double
+
+-- | wrapper for creating signed instances of MPDArg
+newtype Sign a = Sign {unSign :: a}
+  deriving (Show)
+
+instance (Num a,Ord a,Show a) => MPDArg (Sign a) where
+  prep sx | x >= 0 = Args ["+" ++ show x]
+          | otherwise  = Args [show x]
+    where x = unSign sx
 
 addSlashes :: String -> String
 addSlashes = concatMap escapeSpecial

--- a/src/Network/MPD/Commands/Arg.hs
+++ b/src/Network/MPD/Commands/Arg.hs
@@ -77,7 +77,9 @@ instance MPDArg Integer
 instance MPDArg Bool where prep = Args . return . showBool
 instance MPDArg Double
 
--- | wrapper for creating signed instances of MPDArg
+-- | Wrapper for creating signed instances of MPDArg.
+--
+-- @since 0.9.2.0
 newtype Sign a = Sign {unSign :: a}
   deriving (Show)
 

--- a/src/Network/MPD/Commands/PlaybackControl.hs
+++ b/src/Network/MPD/Commands/PlaybackControl.hs
@@ -20,6 +20,7 @@ module Network.MPD.Commands.PlaybackControl
     , previous
     , seek
     , seekId
+    , seekCur
     , stop
     ) where
 
@@ -55,6 +56,11 @@ seek pos = A.runCommand . A.seek pos
 -- | Seek to some point in a song (id version)
 seekId :: MonadMPD m => Id -> FractionalSeconds -> m ()
 seekId id' = A.runCommand . A.seekId id'
+
+-- | Seek to some point in the current song. Absolute time for True in
+-- the frist argument, relative time for False.
+seekCur :: MonadMPD m => Bool -> FractionalSeconds -> m ()
+seekCur bool = A.runCommand . A.seekCur bool
 
 -- | Stop playing.
 stop :: MonadMPD m => m ()

--- a/src/Network/MPD/Commands/PlaybackControl.hs
+++ b/src/Network/MPD/Commands/PlaybackControl.hs
@@ -59,6 +59,8 @@ seekId id' = A.runCommand . A.seekId id'
 
 -- | Seek to some point in the current song. Absolute time for True in
 -- the frist argument, relative time for False.
+--
+-- @since 0.9.2.0
 seekCur :: MonadMPD m => Bool -> FractionalSeconds -> m ()
 seekCur bool = A.runCommand . A.seekCur bool
 

--- a/tests/Network/MPD/Applicative/PlaybackControlSpec.hs
+++ b/tests/Network/MPD/Applicative/PlaybackControlSpec.hs
@@ -40,6 +40,19 @@ spec = do
             seekId (Id 1) 10
                 `with` [("seekid 1 10.0", Right "OK")]
                 `shouldBe` Right ()
+    describe "seekCur" $ do
+        it "sends a seek request on the current song, absolute time" $ do
+            seekCur True 10
+                `with` [("seekcur 10.0", Right "OK")]
+                `shouldBe` Right ()
+        it "sends a seek request on the current song, positive relative time" $ do
+            seekCur False 10
+                `with` [("seekcur +10.0", Right "OK")]
+                `shouldBe` Right ()
+        it "sends a seek request on the current song, positive negative time" $ do
+            seekCur False (-10)
+                `with` [("seekcur -10.0", Right "OK")]
+                `shouldBe` Right ()
 
     describe "stop" $ do
         it "sends a stop request" $ do


### PR DESCRIPTION
Implements the `seekcur` command from the protocol through `seekcur`.
Also, creates `newtype Sign` to create `MPDArgs`'s that need a sign before them,
as otherwise only negative numbers will get a sign (used in `seekcur` for relative seeking).