### PR TITLE
add monadic versions of deleteRange and moveRange

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
-* v0.9.2.0
+* v0.9.2.0 (unreleased)
     - New command: `seekCur`
     - Add `newtype Sign` to pass positive numbers to `MPDArg` with leading `+/-`.
+    - Add monadic versions of `deleteRange` and `moveRange` commands (previously
+      only had applicative versions)
 
 * v0.9.1.0
     - Support partition in Network.MPD.Status

--- a/src/Network/MPD/Applicative/CurrentPlaylist.hs
+++ b/src/Network/MPD/Applicative/CurrentPlaylist.hs
@@ -71,7 +71,6 @@ clear = Command emptyResponse ["clear"]
 delete :: Position -> Command ()
 delete pos = Command emptyResponse ["delete" <@> pos]
 
--- XXX: this does not exist in the monadic version
 -- | Delete a range of songs from the playlist.
 deleteRange :: (Position, Position) -> Command ()
 deleteRange range = Command emptyResponse ["delete" <@> range]

--- a/src/Network/MPD/Commands/CurrentPlaylist.hs
+++ b/src/Network/MPD/Commands/CurrentPlaylist.hs
@@ -17,8 +17,10 @@ module Network.MPD.Commands.CurrentPlaylist
     , add
     , clear
     , delete
+    , deleteRange
     , deleteId
     , move
+    , moveRange
     , moveId
     , playlist
     , playlistFind
@@ -63,6 +65,12 @@ clear = A.runCommand A.clear
 delete :: MonadMPD m => Position -> m ()
 delete = A.runCommand . A.delete
 
+-- | Remove a range of songs from the current playlist.
+--
+-- @since 0.9.2.0
+deleteRange :: MonadMPD m => (Position, Position) -> m ()
+deleteRange = A.runCommand . A.deleteRange
+
 -- | Remove a song from the current playlist.
 deleteId :: MonadMPD m => Id -> m ()
 deleteId = A.runCommand . A.deleteId
@@ -70,6 +78,12 @@ deleteId = A.runCommand . A.deleteId
 -- | Move a song to a given position in the current playlist.
 move :: MonadMPD m => Position -> Position -> m ()
 move pos = A.runCommand . A.move pos
+
+-- | Move a range of songs to a given position in the current playlist.
+--
+-- @since 0.9.2.0
+moveRange :: MonadMPD m => (Position, Position) -> Position -> m ()
+moveRange range = A.runCommand . A.moveRange range
 
 -- | Move a song from (songid) to (playlist index) in the playlist. If to is
 -- negative, it is relative to the current song in the playlist (if there is one).


### PR DESCRIPTION
I'm not sure why these didn't exist. They seem to work as expected.
