### PR TITLE
Remove CPP in Query, base>=4.9 is already required

### DIFF
--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {- |
 Module      : Network.MPD.Commands.Query
 Copyright   : (c) Joachim Fasting 2012
@@ -18,9 +16,7 @@ import           Network.MPD.Commands.Arg
 import           Network.MPD.Commands.Types
 
 import           Data.Monoid
-#if MIN_VERSION_base(4,9,0)
 import           Data.Semigroup
-#endif
 
 -- | An interface for creating MPD queries.
 --
@@ -47,10 +43,8 @@ instance Monoid Query where
     mempty  = Query []
     Query a `mappend` Query b = Query (a ++ b)
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Query where
     (<>) = mappend
-#endif
 
 instance MPDArg Query where
     prep = foldl (<++>) (Args []) . f

--- a/src/Network/MPD/Core.hs
+++ b/src/Network/MPD/Core.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, OverloadedStrings, CPP #-}
+{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Module    : Network.MPD.Core


### PR DESCRIPTION
This is currently used to ensure that `<>` is only defined for `Query`
if base is new enough, but all the supported ghc versions have Semigroup now.

I also removed a CPP pragma that didn't seem to do anything in Network.MPD.Core