### PR TITLE
Proposal: deprecate <&>

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
     - Add `newtype Sign` to pass positive numbers to `MPDArg` with leading `+/-`.
     - Add monadic versions of `deleteRange` and `moveRange` commands (previously
       only had applicative versions)
+    - Deprecate `<&>`, use `<>` instead. `<&>` will be removed in the next major version.
 
 * v0.9.1.0
     - Support partition in Network.MPD.Status

--- a/src/Network/MPD/Commands/Extensions.hs
+++ b/src/Network/MPD/Commands/Extensions.hs
@@ -23,6 +23,7 @@ import qualified Network.MPD.Applicative.StoredPlaylists as A
 import           Control.Monad (liftM)
 import           Data.Traversable (for)
 import           Data.Foldable (for_)
+import           Data.Semigroup ((<>))
 
 -- | This is exactly the same as `update`.
 updateId :: MonadMPD m => Maybe Path -> m Integer
@@ -88,7 +89,7 @@ listAlbums = list Album
 
 -- | List the songs in an album of some artist.
 listAlbum :: MonadMPD m => Artist -> Album -> m [Song]
-listAlbum artist album = find (Artist =? artist <&> Album =? album)
+listAlbum artist album = find (Artist =? artist <> Album =? album)
 
 -- | Retrieve the current playlist.
 -- Equivalent to @playlistinfo Nothing@.

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -29,7 +29,7 @@ import           Data.Semigroup
 -- match any song where the value of artist is \"Foo\" and the value of album
 -- is \"Bar\", we use:
 --
--- > Artist =? "Foo" <&> Album =? "Bar"
+-- > Artist =? "Foo" <> Album =? "Bar"
 newtype Query = Query [Match] deriving Show
 
 -- A single query clause, comprising a metadata key and a desired value.
@@ -62,3 +62,4 @@ m =? s = Query [Match m s]
 infixr 6 <&>
 (<&>) :: Query -> Query -> Query
 (<&>) = mappend
+{-# DEPRECATED (<&>) "will be removed in the next major version of libmpd, use `(<>)` instead" #-}


### PR DESCRIPTION
To my understanding, `<&>` was only needed as a substitute for `<>` on versions of ghc too old to have Semigroup, which have been unsupported since #113. It conflicts with the `<&>` operator in base (under Data.Functor) as well. To this end, I propose that it be deprecated now, and removed in the next major version (presumably 0.10).

If you accept my proposal, I also suggest that the 0.9.2.0 release be made shortly after, so the deprecation notice can be available for as long as possible.