### PR TITLE
Housecleaning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:
   - libmpd-0.9
   - travis
 
-sudo: false
 cache:
   directories:
   - $HOME/.cabal/packages
@@ -25,41 +24,40 @@ matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.0.2"
-    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.2.2"
-    addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  - env: BUILD=cabal GHCVER=8.4.4 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=cabal GHCVER=8.4.4 CABALVER=2.4
     compiler: ": #GHC 8.4.4"
-    addons: {apt: {packages: [cabal-install-1.24,ghc-8.4.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
 
-  - env: BUILD=cabal GHCVER=8.6.3 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.6.3"
-    addons: {apt: {packages: [cabal-install-1.24,ghc-8.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.6.5 CABALVER=2.4
+    compiler: ": #GHC 8.6.5"
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
 
-  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=cabal GHCVER=8.8.4 CABALVER=2.4
+    compiler: ": #GHC 8.8.4"
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.8.4], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=8.10.2 CABALVER=2.4
+    compiler: ": #GHC 8.10.2"
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.10.2], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=head  CABALVER=head
     compiler: ": #GHC HEAD"
-    addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
+    addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
   # The Stack builds.
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default"
-    addons: {apt: {packages: [ghc-8.6.3], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [ghc-8.8.4], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-12"
-    compiler: ": #stack 8.4.4"
-    addons: {apt: {packages: [ghc-8.4.4], sources: [hvr-ghc]}}
+  - env: BUILD=stack ARGS="--resolver lts-14"
+    compiler: ": #stack 8.6.5"
+    addons: {apt: {packages: [ghc-8.6.5], sources: [hvr-ghc]}}
 
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp10,libgmp-dev]}}
 
   allow_failures:
-  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=cabal GHCVER=head  CABALVER=head
   - env: BUILD=stack ARGS="--resolver nightly"
 
 before_install:
@@ -71,7 +69,7 @@ before_install:
 - if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
 
 # Download and unpack the stack executable
-- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH
 - mkdir -p ~/.local/bin
 - |
   if [ `uname` = "Darwin" ]

--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,19 @@
-* v0.9.2.0
+* unreleased
+    - Drop support for GHC < 8.4, require base > 4.11.
+    - Bump `cabal-version` to 2.4.
+    
+* v0.9.2.0 2020-10-02
     - New command: `seekCur`
     - Add `newtype Sign` to pass positive numbers to `MPDArg` with leading `+/-`.
     - Add monadic versions of `deleteRange` and `moveRange` commands (previously
       only had applicative versions)
     - Deprecate `<&>`, use `<>` instead. `<&>` will be removed in the next major version.
 
-* v0.9.1.0
+* v0.9.1.0 2020-01-27
     - Support partition in Network.MPD.Status
     - Ignore unknown key-value pairs in Network.MPD.status so that it breaks much less often.
 
-* v0.9.0.10
+* v0.9.0.10 2019-10-06
     - Port it for newer network library
 
 * v0.9.0, 2014-09-21

--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -47,19 +47,13 @@ Library
       , mtl >= 2.2.2 && < 3
       , old-locale >= 1 && < 2
       , text >= 0.11 && < 2
+      , time >= 1.5 && < 2
 
         -- Additional dependencies
       , data-default-class >= 0.0.1 && < 1
       , network >= 2.6.3.5
       , safe-exceptions >= 0.1 && < 0.2
       , utf8-string >= 0.3.1 && < 1.1
-
-    if impl(ghc >= 7.10.0)
-        Build-Depends:
-            time >= 1.5
-    else
-        Build-Depends:
-            time >= 1.1 && <1.5
 
     Exposed-Modules:
         Network.MPD

--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -45,7 +45,6 @@ Library
       , containers >= 0.3 && < 1
       , filepath >= 1 && < 2
       , mtl >= 2.2.2 && < 3
-      , old-locale >= 1 && < 2
       , text >= 0.11 && < 2
       , time >= 1.5 && < 2
 
@@ -115,7 +114,6 @@ Test-Suite specs
       , containers
       , filepath
       , mtl
-      , old-locale
       , text
       , time
 

--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -1,3 +1,4 @@
+Cabal-Version:      2.4
 Name:               libmpd
 Version:            0.9.2.0
 Synopsis:           An MPD client library.
@@ -19,9 +20,8 @@ Stability:          beta
 Homepage:           http://github.com/vimus/libmpd-haskell#readme
 Bug-reports:        http://github.com/vimus/libmpd-haskell/issues
 
-Tested-With:        GHC ==8.0.1, GHC==8.2.2, GHC==8.4.3, GHC==8.6.1
+Tested-With:        GHC ==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.2
 Build-Type:         Simple
-Cabal-Version:      >= 1.10
 
 Extra-Source-Files:
     README.md
@@ -39,7 +39,7 @@ Library
 
     Build-Depends:
         -- Platform dependencies
-        base >= 4.9 && < 5
+        base >= 4.11 && < 5
       , attoparsec >= 0.10.1 && < 1
       , bytestring >= 0.9 && < 1
       , containers >= 0.3 && < 1

--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -44,7 +44,7 @@ Library
       , bytestring >= 0.9 && < 1
       , containers >= 0.3 && < 1
       , filepath >= 1 && < 2
-      , mtl >= 2.0 && < 3
+      , mtl >= 2.2.2 && < 3
       , old-locale >= 1 && < 2
       , text >= 0.11 && < 2
 

--- a/src/Network/MPD/Applicative/ClientToClient.hs
+++ b/src/Network/MPD/Applicative/ClientToClient.hs
@@ -25,8 +25,6 @@ module Network.MPD.Applicative.ClientToClient
     , sendMessage
     ) where
 
-import           Control.Applicative
-
 import           Network.MPD.Commands.Arg hiding (Command)
 import           Network.MPD.Applicative.Internal
 import           Network.MPD.Applicative.Util

--- a/src/Network/MPD/Applicative/Database.hs
+++ b/src/Network/MPD/Applicative/Database.hs
@@ -14,8 +14,6 @@ The music database.
 
 module Network.MPD.Applicative.Database where
 
-import           Control.Applicative
-
 import qualified Network.MPD.Commands.Arg as Arg
 import           Network.MPD.Commands.Arg hiding (Command)
 import           Network.MPD.Commands.Parse

--- a/src/Network/MPD/Applicative/Internal.hs
+++ b/src/Network/MPD/Applicative/Internal.hs
@@ -38,7 +38,7 @@ import           Data.ByteString.Char8 (ByteString)
 
 import           Network.MPD.Core hiding (getResponse)
 import qualified Network.MPD.Core as Core
-import           Control.Monad.Error
+import           Control.Monad.Except
 import qualified Control.Monad.Fail as Fail
 
 -- | A line-oriented parser that returns a value along with any remaining input.

--- a/src/Network/MPD/Applicative/Internal.hs
+++ b/src/Network/MPD/Applicative/Internal.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE CPP #-}
 
 {- |
 Module      : Network.MPD.Applicative.Internal
@@ -32,7 +31,6 @@ module Network.MPD.Applicative.Internal
     , runCommand
     ) where
 
-import           Control.Applicative
 import           Control.Monad
 import           Data.ByteString.Char8 (ByteString)
 

--- a/src/Network/MPD/Applicative/Stickers.hs
+++ b/src/Network/MPD/Applicative/Stickers.hs
@@ -26,8 +26,6 @@ import           Network.MPD.Commands.Arg hiding (Command)
 import           Network.MPD.Commands.Types
 import           Network.MPD.Util
 
-import           Control.Applicative
-
 import qualified Data.ByteString.UTF8 as UTF8
 
 -- | Read sticker value for the object specified.

--- a/src/Network/MPD/Applicative/StoredPlaylists.hs
+++ b/src/Network/MPD/Applicative/StoredPlaylists.hs
@@ -32,8 +32,6 @@ import           Network.MPD.Commands.Arg hiding (Command)
 import           Network.MPD.Commands.Types
 import           Network.MPD.Util
 
-import           Control.Applicative
-
 -- | List song items in the playlist.
 listPlaylist :: PlaylistName -> Command [Path]
 listPlaylist plName = Command p ["listplaylist" <@> plName]

--- a/src/Network/MPD/Commands/CurrentPlaylist.hs
+++ b/src/Network/MPD/Commands/CurrentPlaylist.hs
@@ -47,7 +47,7 @@ import           Network.MPD.Commands.Types
 import           Network.MPD.Core
 import           Network.MPD.Util
 
-import           Control.Monad.Error (throwError)
+import           Control.Monad.Except (throwError)
 
 -- | Like 'add', but returns a playlist id.
 addId :: MonadMPD m => Path -> Maybe Position -> m Id

--- a/src/Network/MPD/Commands/Extensions.hs
+++ b/src/Network/MPD/Commands/Extensions.hs
@@ -23,7 +23,6 @@ import qualified Network.MPD.Applicative.StoredPlaylists as A
 import           Control.Monad (liftM)
 import           Data.Traversable (for)
 import           Data.Foldable (for_)
-import           Data.Semigroup ((<>))
 
 -- | This is exactly the same as `update`.
 updateId :: MonadMPD m => Maybe Path -> m Integer

--- a/src/Network/MPD/Commands/Parse.hs
+++ b/src/Network/MPD/Commands/Parse.hs
@@ -13,7 +13,7 @@ module Network.MPD.Commands.Parse where
 import           Network.MPD.Commands.Types
 
 import           Control.Applicative
-import           Control.Monad.Error
+import           Control.Monad.Except
 import           Data.Maybe (fromMaybe)
 
 import           Network.MPD.Util

--- a/src/Network/MPD/Commands/Parse.hs
+++ b/src/Network/MPD/Commands/Parse.hs
@@ -12,7 +12,6 @@ module Network.MPD.Commands.Parse where
 
 import           Network.MPD.Commands.Types
 
-import           Control.Applicative
 import           Control.Monad.Except
 import           Data.Maybe (fromMaybe)
 

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -15,9 +15,6 @@ module Network.MPD.Commands.Query (Query, (=?), (<&>), anything) where
 import           Network.MPD.Commands.Arg
 import           Network.MPD.Commands.Types
 
-import           Data.Monoid
-import           Data.Semigroup
-
 -- | An interface for creating MPD queries.
 --
 -- For example, to match any song where the value of artist is \"Foo\", we

--- a/src/Network/MPD/Core.hs
+++ b/src/Network/MPD/Core.hs
@@ -26,7 +26,6 @@ import           Network.MPD.Core.Class
 import           Network.MPD.Core.Error
 
 import           Data.Char (isDigit)
-import           Control.Applicative (Applicative(..), (<$>), (<*))
 import qualified Control.Exception as E
 import           Control.Exception.Safe (catch, catchAny)
 import           Control.Monad (ap, unless)

--- a/src/Network/MPD/Core/Class.hs
+++ b/src/Network/MPD/Core/Class.hs
@@ -14,7 +14,7 @@ import           Data.ByteString (ByteString)
 
 import           Network.MPD.Core.Error (MPDError)
 
-import           Control.Monad.Error (MonadError)
+import           Control.Monad.Except (MonadError)
 
 type Password = String
 

--- a/src/Network/MPD/Core/Error.hs
+++ b/src/Network/MPD/Core/Error.hs
@@ -15,7 +15,6 @@ MPD errors.
 module Network.MPD.Core.Error where
 
 import qualified Control.Exception as E
-import           Control.Monad.Error (Error(..))
 import           Data.Typeable
 
 -- | The MPDError type is used to signal errors, both from the MPD and
@@ -44,10 +43,6 @@ instance Show MPDError where
                           ]
     show (Custom s)     = s
     show (ACK _ s)      = s
-
-instance Error MPDError where
-    noMsg  = Custom "An error occurred"
-    strMsg = Custom
 
 -- | Represents various MPD errors (aka. ACKs).
 data ACKType = InvalidArgument  -- ^ Invalid argument passed (ACK 2)

--- a/src/Network/MPD/Util.hs
+++ b/src/Network/MPD/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- | Module    : Network.MPD.Util
 -- Copyright   : (c) Ben Sinclair 2005-2009, Joachim Fasting 2010
 -- License     : MIT (see LICENSE)
@@ -17,11 +17,7 @@ import           Control.Arrow
 
 import           Data.Time.Format (ParseTime, parseTimeM, FormatTime, formatTime)
 
-#if MIN_VERSION_time(1,5,0)
 import           Data.Time.Format (defaultTimeLocale)
-#else
-import           System.Locale (defaultTimeLocale)
-#endif
 
 import qualified Prelude
 import           Prelude hiding        (break, take, drop, dropWhile, read)

--- a/src/Network/MPD/Util.hs
+++ b/src/Network/MPD/Util.hs
@@ -15,7 +15,7 @@ module Network.MPD.Util (
 
 import           Control.Arrow
 
-import           Data.Time.Format (ParseTime, parseTime, FormatTime, formatTime)
+import           Data.Time.Format (ParseTime, parseTimeM, FormatTime, formatTime)
 
 #if MIN_VERSION_time(1,5,0)
 import           Data.Time.Format (defaultTimeLocale)
@@ -50,7 +50,7 @@ parseDate = parseMaybe p
 
 -- Parse date in iso 8601 format
 parseIso8601 :: (ParseTime t) => ByteString -> Maybe t
-parseIso8601 = parseTime defaultTimeLocale iso8601Format . UTF8.toString
+parseIso8601 = parseTimeM True defaultTimeLocale iso8601Format . UTF8.toString
 
 formatIso8601 :: FormatTime t => t -> String
 formatIso8601 = formatTime defaultTimeLocale iso8601Format

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
-resolver: lts-14.21
+resolver: lts-16.16
 
 packages:
 - '.'

--- a/tests/StringConn.hs
+++ b/tests/StringConn.hs
@@ -13,7 +13,7 @@ module StringConn where
 
 import           Control.Applicative
 import           Prelude hiding (exp)
-import           Control.Monad.Error
+import           Control.Monad.Except
 import           Control.Monad.Identity
 import           Control.Monad.Reader
 import           Control.Monad.State
@@ -37,7 +37,7 @@ data Result a
       deriving (Show, Eq)
 
 newtype StringMPD a =
-    SMPD { runSMPD :: ErrorT MPDError
+    SMPD { runSMPD :: ExceptT MPDError
                       (StateT [(Expect, Response String)]
                        (ReaderT Password Identity)) a
          } deriving (Functor, Applicative, Monad, MonadError MPDError)
@@ -73,4 +73,4 @@ testMPDWithPassword :: (Eq a)
         -> Password                    -- ^ A password to be supplied.
         -> StringMPD a                 -- ^ The MPD action to run.
         -> Response a
-testMPDWithPassword pairs passwd m = runIdentity $ runReaderT (evalStateT (runErrorT $ runSMPD m) pairs) passwd
+testMPDWithPassword pairs passwd m = runIdentity $ runReaderT (evalStateT (runExceptT $ runSMPD m) pairs) passwd


### PR DESCRIPTION
## Remove deprecated functions
- from `mtl`, `Control.Monad.Error` has been deprecated in favor of `Control.Monad.Except`. We replace all the `Error`'s with `Except`'s and bump `mtl` to version `2.2.2`, as `Except` was added in `mtl-2.2.1`, and `mtl-2.2.2` works for any `base>4`, so bumping it is a formality anyway.
- just have `time>=1.5` in the cabal file, as support for `7.10` has been dropped anyway.
- `parseTime` has been deprecated, so it is replaced with `parseTimeM True`
- remove old-locale as it is unneeded.

## Drop support for ghc<8.4
- require base>4.11
- test for ghc 8.4-8.10
- test for stack lts 16.16 and 14.21
- bump cabal used to 2.4
- drop alex and happy from travis because they don't seem to do anything
- using ghc>=8.4 also allows us to drop a bunch of imports that no longer do anything.