### PR TITLE
Support MPD 0.21 style filters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,8 @@
     - Bump `cabal-version` to 2.4.
     - Add `Ord` instance for `PlaylistName`, `Path`, and `Value`
     - Add support for MPD 0.21 style filters to the `Query` type,
-      see Filters in the MPD protocol documentation. Implemented through the
-      added combinators `/=?`, `%?`, `~?`, `/~?`, `qNot`, `qModSince`, `qFile`, `qBase`.
+      see [Filters](https://www.musicpd.org/doc/html/protocol.html#filters) in the MPD protocol documentation. 
+      Implemented through the added combinators `/=?`, `%?`, `~?`, `/~?`, `qNot`, `qModSince`, `qFile`, `qBase`.
     
 * v0.9.2.0 2020-10-02
     - New command: `seekCur`

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-* unreleased
+* v0.9.3.0 2021-01-02
     - Drop support for GHC < 8.4, require base > 4.11.
     - Bump `cabal-version` to 2.4.
     - Add `Ord` instance for `PlaylistName`, `Path`, and `Value`

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
     - Drop support for GHC < 8.4, require base > 4.11.
     - Bump `cabal-version` to 2.4.
     - Add `Ord` instance for `PlaylistName`, `Path`, and `Value`
+    - Add support for MPD 0.21 style filters to the `Query` type,
+      see Filters in the MPD protocol documentation. Implemented through the
+      added combinators `/=?`, `%?`, `~?`, `/~?`, `qNot`, `qModSince`, `qFile`, `qBase`.
     
 * v0.9.2.0 2020-10-02
     - New command: `seekCur`

--- a/libmpd.cabal
+++ b/libmpd.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:      2.4
 Name:               libmpd
-Version:            0.9.2.0
+Version:            0.9.3.0
 Synopsis:           An MPD client library.
 Description:        A client library for MPD, the Music Player Daemon.
 Category:           Network, Sound

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -10,7 +10,7 @@ Portability : unportable
 Query interface.
 -}
 
-module Network.MPD.Commands.Query (Query, (=?) ,(/=?), (%?), (~?), (/~?), qNot, qModSince, (<&>), anything) where
+module Network.MPD.Commands.Query (Query, (=?) ,(/=?), (%?), (~?), (/~?), qNot, qModSince, qFile, qBase, (<&>), anything) where
 
 import           Network.MPD.Commands.Arg
 import           Network.MPD.Commands.Types
@@ -43,6 +43,8 @@ data Expr = Exact Match
           | Contains Match
           | Regex Match
           | RegexNot Match
+          | File FilePath
+          | Base FilePath
           | ModifiedSince UTCTime
           | ExprNot Expr
           | ExprAnd Expr Expr
@@ -58,6 +60,8 @@ instance Show Expr where
                                    "\\\"" ++ toString query ++ "\\\"" ++ ")"
  show (RegexNot (Match meta query)) = "(" ++ show meta ++ " !~ " ++
                                    "\\\"" ++ toString query ++ "\\\"" ++ ")"
+ show (File file) = "(file == " ++ "\\\"" ++ show file ++ "\\\"" ++ ")"
+ show (Base dir) = "(base " ++ "\\\"" ++ show dir ++ "\\\"" ++ ")"
  show (ModifiedSince time) = "(modified-since " ++  "\\\"" ++
                            formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time ++
                            "\\\"" ++ ")"
@@ -128,6 +132,16 @@ qNot (Filter ex) = Filter (ExprNot ex)
 -- requires MPD 0.21 or newer.
 qModSince :: UTCTime -> Query
 qModSince time = Filter (ModifiedSince time)
+
+-- | Create a query for the full song URI relative to the music directory.
+-- requires MPD 0.21 or newer.
+qFile :: FilePath -> Query
+qFile file = Filter (File file)
+
+-- | Limit the query to the given directory, relative to the music directory.
+-- requires MPD 0.21 or newer.
+qBase :: FilePath -> Query
+qBase dir = Filter (Base dir)
 
 -- | Combine queries.
 infixr 6 <&>

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -102,44 +102,60 @@ anything = mempty
 m =? s = Query [Match m s]
 
 -- | Create a query matching a tag with anything but a value.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 (/=?) :: Metadata -> Value -> Query
 m /=? s = Filter (ExactNot (Match m s))
 
 -- | Create a query for a tag containing a value.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 (%?) :: Metadata -> Value -> Query
 m %? s = Filter (Contains (Match m s))
 
 -- | Create a query matching a tag with regexp.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 (~?) :: Metadata -> Value -> Query
 m ~? s = Filter (Regex (Match m s))
 
 -- | Create a query matching a tag with anything but a regexp.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 (/~?) :: Metadata -> Value -> Query
 m /~? s = Filter (RegexNot (Match m s))
 
 -- | Negate a Query.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 qNot :: Query -> Query
 qNot (Query ms) = Filter (ExprNot (toExpr ms))
 qNot (Filter (ExprNot ex)) = Filter ex
 qNot (Filter ex) = Filter (ExprNot ex)
 
 -- | Create a query for songs modified since a date.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 qModSince :: UTCTime -> Query
 qModSince time = Filter (ModifiedSince time)
 
 -- | Create a query for the full song URI relative to the music directory.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 qFile :: Path -> Query
 qFile file = Filter (File file)
 
 -- | Limit the query to the given directory, relative to the music directory.
--- requires MPD 0.21 or newer.
+-- Requires MPD 0.21 or newer.
+--
+-- @since 0.9.3.0
 qBase :: Path -> Query
 qBase dir = Filter (Base dir)
 

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -43,8 +43,8 @@ data Expr = Exact Match
           | Contains Match
           | Regex Match
           | RegexNot Match
-          | File FilePath
-          | Base FilePath
+          | File Path
+          | Base Path
           | ModifiedSince UTCTime
           | ExprNot Expr
           | ExprAnd Expr Expr
@@ -60,8 +60,8 @@ instance Show Expr where
                                    "\\\"" ++ toString query ++ "\\\"" ++ ")"
  show (RegexNot (Match meta query)) = "(" ++ show meta ++ " !~ " ++
                                    "\\\"" ++ toString query ++ "\\\"" ++ ")"
- show (File file) = "(file == " ++ "\\\"" ++ show file ++ "\\\"" ++ ")"
- show (Base dir) = "(base " ++ "\\\"" ++ show dir ++ "\\\"" ++ ")"
+ show (File file) = "(file == " ++ "\\\"" ++ toString file ++ "\\\"" ++ ")"
+ show (Base dir) = "(base " ++ "\\\"" ++ toString dir ++ "\\\"" ++ ")"
  show (ModifiedSince time) = "(modified-since " ++  "\\\"" ++
                            formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time ++
                            "\\\"" ++ ")"
@@ -135,12 +135,12 @@ qModSince time = Filter (ModifiedSince time)
 
 -- | Create a query for the full song URI relative to the music directory.
 -- requires MPD 0.21 or newer.
-qFile :: FilePath -> Query
+qFile :: Path -> Query
 qFile file = Filter (File file)
 
 -- | Limit the query to the given directory, relative to the music directory.
 -- requires MPD 0.21 or newer.
-qBase :: FilePath -> Query
+qBase :: Path -> Query
 qBase dir = Filter (Base dir)
 
 -- | Combine queries.

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -63,7 +63,7 @@ instance Show Expr where
  show (File file) = "(file == " ++ "\\\"" ++ toString file ++ "\\\"" ++ ")"
  show (Base dir) = "(base " ++ "\\\"" ++ toString dir ++ "\\\"" ++ ")"
  show (ModifiedSince time) = "(modified-since " ++  "\\\"" ++
-                           formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time ++
+                           formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" time ++
                            "\\\"" ++ ")"
  show (ExprNot expr) = "(!" ++ show expr ++ ")"
  show (ExprAnd e1 e2) = "(" ++ show e1 ++ " AND " ++ show e2 ++ ")"

--- a/tests/Network/MPD/Applicative/QuerySpec.hs
+++ b/tests/Network/MPD/Applicative/QuerySpec.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Network.MPD.Applicative.QuerySpec (main, spec) where
+
+import           TestUtil
+import           Unparse
+import           Data.Time
+import           Data.Time.Calendar.OrdinalDate (fromOrdinalDate)
+
+import           Network.MPD.Applicative.Database
+import           Network.MPD.Commands.Query
+import           Network.MPD.Commands.Types
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+    describe "=?" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (Title =? "Bar")
+                `with` [("find Title \"Bar\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "=? <> =?" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (Title =? "Bar" <> Artist =? "Baz")
+                `with` [("find Title \"Bar\" Artist \"Baz\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "/=?" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (Title /=? "Bar")
+                `with` [("find \"(Title != \\\"Bar\\\")\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "%?" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (Title %? "Bar")
+                `with` [("find \"(Title contains \\\"Bar\\\")\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "~?" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (Title ~? "Bar")
+                `with` [("find \"(Title =~ \\\"Bar\\\")\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "/~?" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (Title /~? "Bar")
+                `with` [("find \"(Title !~ \\\"Bar\\\")\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "qFile" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (qFile "Bar.ogg")
+                `with` [("find \"(file == \\\"Bar.ogg\\\")\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "qBase" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (qBase "Bar")
+                `with` [("find \"(base \\\"Bar\\\")\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "qModSince" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (qModSince (UTCTime {utctDay = fromOrdinalDate 2005 348, utctDayTime = 40743}))
+                `with` [("find \"(modified-since \\\"2005-12-14T11:19:03\\\")\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "qNot" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (qNot (Title =? "Bar"))
+                `with` [("find \"(!(Title == \\\"Bar\\\"))\"", Right resp)]
+                `shouldBe` Right [obj]
+    describe "<>" $ do
+        it "returns songs exactly matching a query" $ do
+            let obj  = defaultSong "Foo.ogg"
+                resp = unparse obj ++ "OK"
+            find (Title =? "Bar" <> Artist /=? "Baz")
+                `with` [("find \"((Title == \\\"Bar\\\") AND (Artist != \\\"Baz\\\"))\"", Right resp)]
+                `shouldBe` Right [obj]

--- a/tests/Network/MPD/Applicative/QuerySpec.hs
+++ b/tests/Network/MPD/Applicative/QuerySpec.hs
@@ -76,7 +76,7 @@ spec = do
             let obj  = defaultSong "Foo.ogg"
                 resp = unparse obj ++ "OK"
             find (qModSince (UTCTime {utctDay = fromOrdinalDate 2005 348, utctDayTime = 40743}))
-                `with` [("find \"(modified-since \\\"2005-12-14T11:19:03\\\")\"", Right resp)]
+                `with` [("find \"(modified-since \\\"2005-12-14T11:19:03Z\\\")\"", Right resp)]
                 `shouldBe` Right [obj]
     describe "qNot" $ do
         it "returns songs exactly matching a query" $ do


### PR DESCRIPTION
In version 0.21 MPD added a more expressive syntax for [filters](https://www.musicpd.org/doc/html/protocol.html#filters). This PR implements it in `libmpd` in a backwards compatible way by changing the `Query` type from
```haskell
data Query = Query [Match]
```
to:
```haskell
data Query = Query [Match] | Filter Expr
```
where `Expr` corrisponds to the newer syntax. This change is backwards compatible, both in the sense that it doesn't break existing Haskell code using libmpd (tests pass, vimus compiles), and that libmpd generates MPD 0.20 style filters for queries not created with the new combinators.

The new combinators are:

+ `Tag /=? "value"`  for tag is not equal to "value"
+ `Tag %? "value"`   for tag contains the string "value" as a substring
+ `Tag ~? "regexp"`  for tag matches "regexp"
+ `Tag /~? "regexp"` for tag doesn't match "regexp"
+ `qFile path`       for matching filepath path (relative to the music directory)
+ `qBase dir`        for restrincting the search to subdirectory dir
+ `qModSince time`   for restricting the search to files modified after some time
+ `qNot query`       for negating a query

Notice that this doesn't implement the `AudioFormat` filters, because I'm not entirely sure how those work. At any rate like the rest of this stuff they can be implemented without breaking backwards compatibility because the user only creates `Query`'s with the combinators anyway.

I haven't created tests for these yet, primarily because I haven't really been able to understand the test suite all that well. For example, why does [this](https://github.com/vimus/libmpd-haskell/blob/ac1a7f6492d50616588f01e0b107fb4baa617467/tests/Network/MPD/Applicative/DatabaseSpec.hs#L23-L29) work? The default song doesn't have a title.

Edit: also, this closes #77, and is related to #123.