### PR TITLE
add `Ord` instance for `PlaylistName`, `Path`, and `Value`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 * unreleased
     - Drop support for GHC < 8.4, require base > 4.11.
     - Bump `cabal-version` to 2.4.
+    - Add `Ord` instance for `PlaylistName`, `Path`, and `Value`
     
 * v0.9.2.0 2020-10-02
     - New command: `seekCur`

--- a/src/Network/MPD/Commands/Types.hs
+++ b/src/Network/MPD/Commands/Types.hs
@@ -74,7 +74,7 @@ type Title  = Value
 -- | Used for commands which require a playlist name.
 -- If empty, the current playlist is used.
 newtype PlaylistName = PlaylistName ByteString
-  deriving (Eq, Show, MPDArg)
+  deriving (Eq, Show, Ord, MPDArg)
 
 instance ToString PlaylistName where
   toString (PlaylistName x) = UTF8.toString x
@@ -87,7 +87,7 @@ instance IsString PlaylistName where
 -- | Used for commands which require a path within the database.
 -- If empty, the root path is used.
 newtype Path = Path ByteString
-  deriving (Eq, Show, MPDArg)
+  deriving (Eq, Show, Ord, MPDArg)
 
 instance ToString Path where
   toString (Path x) = UTF8.toString x
@@ -124,7 +124,7 @@ instance MPDArg Metadata
 
 -- | A metadata value.
 newtype Value = Value ByteString
-  deriving (Eq, Show, MPDArg)
+  deriving (Eq, Show, Ord, MPDArg)
 
 instance ToString Value where
   toString (Value x) = UTF8.toString x

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -51,8 +51,6 @@ prop_parseOutputs :: [Device] -> Expectation
 prop_parseOutputs ds =
     Right ds `shouldBe` (parseOutputs . map UTF8.fromString . lines . concatMap unparse) ds
 
-deriving instance Ord Value
-
 prop_parseSong :: Song -> Expectation
 prop_parseSong s = Right (sortTags s) `shouldBe` sortTags `fmap` (parseSong . toAssocList . map UTF8.fromString . lines . unparse) s
   where


### PR DESCRIPTION
Useful for sorting them alphabetically.