### PR TITLE
update haddocks

### DIFF
--- a/src/Network/MPD/Applicative/CurrentPlaylist.hs
+++ b/src/Network/MPD/Applicative/CurrentPlaylist.hs
@@ -170,6 +170,8 @@ clearTagId id' tags = Command emptyResponse ["cleartagid" <@> id' <++> tags]
 
 -- | Specify portion of song that shall be played.
 -- Both ends of the range are optional; omitting both plays everything.
+--
+-- Since MPD 0.19.
 rangeId :: Id -> (Maybe Double, Maybe Double) -> Command ()
 rangeId id' (mbStart, mbEnd) = Command emptyResponse ["rangeid " ++ show id' ++ " " ++ arg ]
   where arg = maybe "" show mbStart ++ ":" ++ maybe "" show mbEnd

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -102,35 +102,40 @@ anything = mempty
 m =? s = Query [Match m s]
 
 -- | Create a query matching a tag with anything but a value.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 (/=?) :: Metadata -> Value -> Query
 m /=? s = Filter (ExactNot (Match m s))
 
 -- | Create a query for a tag containing a value.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 (%?) :: Metadata -> Value -> Query
 m %? s = Filter (Contains (Match m s))
 
 -- | Create a query matching a tag with regexp.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 (~?) :: Metadata -> Value -> Query
 m ~? s = Filter (Regex (Match m s))
 
 -- | Create a query matching a tag with anything but a regexp.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 (/~?) :: Metadata -> Value -> Query
 m /~? s = Filter (RegexNot (Match m s))
 
 -- | Negate a Query.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 qNot :: Query -> Query
@@ -139,21 +144,24 @@ qNot (Filter (ExprNot ex)) = Filter ex
 qNot (Filter ex) = Filter (ExprNot ex)
 
 -- | Create a query for songs modified since a date.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 qModSince :: UTCTime -> Query
 qModSince time = Filter (ModifiedSince time)
 
 -- | Create a query for the full song URI relative to the music directory.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 qFile :: Path -> Query
 qFile file = Filter (File file)
 
 -- | Limit the query to the given directory, relative to the music directory.
--- Requires MPD 0.21 or newer.
+--
+-- Since MPD 0.21.
 --
 -- @since 0.9.3.0
 qBase :: Path -> Query


### PR DESCRIPTION
The new `Query` combinator haddocks were missing a newline.
I also documented that `rangeId` needs MPD 0.19 or later.