### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ music playing daemon. Requires MPD version 0.19 or later.
 
 ## Getting
 * [Latest release on Hackage]
-* `git clone git://github.com/vimus/libmpd-haskell.git`
+* `git clone https://github.com/vimus/libmpd-haskell.git`
 
 [Latest release on Hackage]: https://hackage.haskell.org/package/libmpd "libmpd-haskell on Hackage"
 


### PR DESCRIPTION
Using the git protocol gives the following error:
```
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```