### PR TITLE
Fix build issues

### DIFF
--- a/src/Network/MPD/Applicative/Internal.hs
+++ b/src/Network/MPD/Applicative/Internal.hs
@@ -45,14 +45,13 @@ newtype Parser a
       deriving Functor
 
 instance Monad Parser where
-    return a  = Parser $ \input -> Right (a, input)
     p1 >>= p2 = Parser $ \input -> runParser p1 input >>= uncurry (runParser . p2)
 
 instance Fail.MonadFail Parser where
     fail = Prelude.fail
 
 instance Applicative Parser where
-    pure  = return
+    pure  a = Parser $ \input -> Right (a, input)
     (<*>) = ap
 
 -- | Convert a regular parser.

--- a/src/Network/MPD/Commands/Parse.hs
+++ b/src/Network/MPD/Commands/Parse.hs
@@ -12,8 +12,7 @@ module Network.MPD.Commands.Parse where
 
 import           Network.MPD.Commands.Types
 
-import           Control.Monad
-import           Control.Monad.Except
+import           Control.Monad (foldM)
 import           Data.Maybe (fromMaybe)
 
 import           Network.MPD.Util

--- a/src/Network/MPD/Commands/Query.hs
+++ b/src/Network/MPD/Commands/Query.hs
@@ -77,15 +77,15 @@ toExpr (m:ms) = ExprAnd (Exact m) (toExpr ms)
 
 instance Monoid Query where
     mempty  = Query []
-    Query  a  `mappend` Query    b  = Query (a ++ b)
-    Query  [] `mappend` Filter   b  = Filter b
-    Filter a  `mappend` Query    [] = Filter a
-    Query  a  `mappend` Filter   b  = Filter (ExprAnd (toExpr a) b)
-    Filter a  `mappend` Query    b  = Filter (ExprAnd a (toExpr b))
-    Filter a  `mappend` Filter   b  = Filter (a <> b)
 
 instance Semigroup Query where
-    (<>) = mappend
+    Query  a  <> Query    b  = Query (a ++ b)
+    Query  [] <> Filter   b  = Filter b
+    Filter a  <> Query    [] = Filter a
+    Query  a  <> Filter   b  = Filter (ExprAnd (toExpr a) b)
+    Filter a  <> Query    b  = Filter (ExprAnd a (toExpr b))
+    Filter a  <> Filter   b  = Filter (a <> b)
+
 instance Semigroup Expr where
   ex1 <> ex2 = ExprAnd ex1 ex2
 

--- a/tests/StringConn.hs
+++ b/tests/StringConn.hs
@@ -14,6 +14,7 @@ module StringConn where
 import           Control.Applicative
 import           Prelude hiding (exp)
 import           Control.Monad.Except
+import           Control.Monad
 import           Control.Monad.Identity
 import           Control.Monad.Reader
 import           Control.Monad.State


### PR DESCRIPTION
libmpd had bitrotten, leading it to not building with newer versions of other packages.
This patch fixes those issues and compiled with `-Wall -Werror`