### PR TITLE
Fix IO exception on socket connection error

### DIFF
--- a/src/Network/MPD/Core.hs
+++ b/src/Network/MPD/Core.hs
@@ -136,7 +136,7 @@ mpdOpen = MPD $ do
         getAddr host port = getAddrInfo (Just defaultHints) (Just host) (Just $ show port)
 
         safeConnectTo (sock,addr) =
-            (connect sock addr) >> (Just <$> socketToHandle sock ReadWriteMode)
+            ((connect sock addr) >> (Just <$> socketToHandle sock ReadWriteMode))
             `catchAny` const (return Nothing)
         checkConn = do
             singleMsg <- send ""


### PR DESCRIPTION
Resolves #114. It turns out that there was just a missing pair of parentheses, so errors in `connect sock addr` were not handled by the `catchAny`. 